### PR TITLE
Feb29 deployment bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ The following environment variables will need to be configured:
 
 	RAILS_ENV=production
 
+Install Mina:
+
+	gem install mina
+
 If running deployment to a fresh environment use:
 
 	mina setup:all

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Local machine needs to be configured with the following environment variables:
 	export POLARISCOPEDEPLOYTOLOCATION='<deploymentpath>'
 
 ### Remote Environment Setup - Production
-The following environment variables will need to be configured:
+The following environment variables will need to be configured within the ~/.bashrc file:
 
 	export PSAAPPMYSQLUSERNAME='<username>'
 	export PSAAPPMYSQLPASSWORD='<password>'

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ For Ubuntu/Debian based distros:
 
 For Red Hat/CentOs based distros:
 
-	yum install build-essential mysql-server ruby-devel zlib1g-devel libmysqlclient-devel libsqlite3-devel git
+	yum install build-essential mariadb mariadb-server ruby-devel zlib-devel mariadb-devel sqlite-devel git libyaml-devel readline-devel libffi-devel openssl-devel httpd-devel
+
+	yum groupinstall 'Development Tools'
 
 Install Rails:
 

--- a/config/dbcreate.sh
+++ b/config/dbcreate.sh
@@ -1,0 +1,14 @@
+
+
+set -e
+
+DATABASE=polariscope_two
+Q1="CREATE DATABASE IF NOT EXISTS $DATABASE;"
+Q2="GRANT USAGE ON polariscope_two.* TO $PSAAPPMYSQLUSERNAME@localhost IDENTIFIED BY '$PSAAPPMYSQLPASSWORD';"
+Q3="GRANT ALL PRIVILEGES ON polariscope_two.* TO $PSAAPPMYSQLUSERNAME@localhost;"
+Q4="FLUSH PRIVILEGES;"
+SQL="${Q1}${Q2}${Q3}${Q4}"
+
+mysql -uroot -p -e "$SQL"
+
+echo "--->Done"

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -2,6 +2,7 @@ require 'mina/bundler'
 require 'mina/rails'
 require 'mina/git'
 require 'mina/rvm'
+require 'etc'
 
 
 #Basic Settings:
@@ -51,9 +52,11 @@ task :'fresh:db' do
 end
 
 task :'db:configure' do
-  if File.exist?('#{deploy_to}/#{shared_path}/config/dbExists')
+  if File.exist?("#{deploy_to}/shared/config/dbExists")
+    queue %[echo "Existing installation, migrating"]
     invoke :'rails:db_migrate'
   else
+    queue %[echo "Fresh installation, using db:setup"]
     invoke :'fresh:db'
     queue! %[touch "#{deploy_to}/#{shared_path}/config/dbExists"]
   end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -17,7 +17,7 @@ set :rvm_path, '$HOME/.rvm/bin/rvm'
 
 # Manually create these paths in shared/ (eg: shared/config/database.yml) in your server.
 # They will be linked in the 'deploy:link_shared_paths' step.
-set :shared_paths, ['config/database.yml', 'log', 'tmp', 'config/web_action_api.yml', 'config/secrets.yml', 'config/Rakefile']
+set :shared_paths, ['config/database.yml', 'log', 'tmp', 'config/web_action_api.yml', 'config/secrets.yml', 'config/Rakefile', 'config/dbcreate.sh']
 
 # Optional settings:
 #   set :user, 'foobar'    # Username in the server to SSH to.
@@ -62,17 +62,9 @@ end
 desc "Create new database"
 task :'setup:db' => :environment do
   queue! %{
-    echo "-----> Create SQL query"
-    DATABASE=polariscope_two
-    Q1="CREATE DATABASE IF NOT EXISTS $DATABASE;"
-    Q2="GRANT USAGE ON polariscope_two.* TO $PSAAPPMYSQLUSERNAME@localhost IDENTIFIED BY '$PSAAPPMYSQLPASSWORD';"
-    Q3="GRANT ALL PRIVILEGES ON polariscope_two.* TO $PSAAPPMYSQLUSERNAME@localhost;"
-    Q4="FLUSH PRIVILEGES;"
-    SQL="${Q1}${Q2}${Q3}${Q4}"
     echo "-----> Execute SQL query to create DB and user"
     echo "-----> Enter MySQL root password on prompt below"
-    #{echo_cmd %[mysql -uroot -p -e "$SQL"]}
-    echo "-----> Done"
+    #{echo_cmd %["#{deploy_to}/#{shared_path}/config/dbcreate.sh"]}
   }
 end
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -17,7 +17,7 @@ set :rvm_path, '$HOME/.rvm/bin/rvm'
 
 # Manually create these paths in shared/ (eg: shared/config/database.yml) in your server.
 # They will be linked in the 'deploy:link_shared_paths' step.
-set :shared_paths, ['config/database.yml', 'log', 'tmp', 'config/web_action_api.yml', 'config/secrets.yml', 'config/Rakefile', 'config/dbcreate.sh']
+set :shared_paths, ['config/database.yml', 'log', 'tmp', 'config/web_action_api.yml', 'config/secrets.yml', 'config/Rakefile']
 
 # Optional settings:
 #   set :user, 'foobar'    # Username in the server to SSH to.
@@ -62,9 +62,15 @@ end
 desc "Create new database"
 task :'setup:db' => :environment do
   queue! %{
+    echo "-----> Create SQL query"
+    DATABASE=polariscope_two
+    Q1="CREATE DATABASE IF NOT EXISTS $DATABASE;"
+    Q2="GRANT USAGE ON polariscope_two.* TO $PSAAPPMYSQLUSERNAME@localhost IDENTIFIED BY '$PSAAPPMYSQLPASSWORD';"
+    Q3="GRANT ALL PRIVILEGES ON polariscope_two.* TO $PSAAPPMYSQLUSERNAME@localhost;"
+    Q4="FLUSH PRIVILEGES;"
     echo "-----> Execute SQL query to create DB and user"
     echo "-----> Enter MySQL root password on prompt below"
-    #{echo_cmd %["#{deploy_to}/#{shared_path}/config/dbcreate.sh"]}
+    #{echo_cmd %[mysql -uroot -p -e "$Q1" && "$Q2" && "$Q3" && "$Q4" && echo "---> Done"]}
   }
 end
 


### PR DESCRIPTION
Fixes for the following issues:

**https://github.com/samnissen/polariscope_2/issues/21** Edit made to README.md to reflect correct installation calls for CentOS/Redhat linux OS

**https://github.com/samnissen/polariscope_2/issues/22** - Edit made to README.md to explicitly state remote environment variables should be added to ~/.bashrc

**https://github.com/samnissen/polariscope_2/issues/27** - Change the execution of SQL statements so that they are processed individually rather than as a bulk. Prevents further execution when error code is returned.

**https://github.com/samnissen/polariscope_2/issues/28** - Removed fresh database creation from setup:all and moved into :deploy task. This now calls back to db:configure which checks for a dbExists file in the shared path. If not present mina assumes a fresh install and calls out to fresh:db and creates the dbExists file for subsequent deployments. Otherwise db_migrate is used.

**https://github.com/samnissen/polariscope_2/issues/30** - As per ticket additions made to create the files/filepaths during setup task.
