### PR TITLE
Mar16 mina safe deploy

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -56,7 +56,8 @@ task :'db:configure' do
     targetpath="#{deploy_to}/#{shared_path}/config/dbExists"
     if [ -e "$targetpath" ]
     then
-      echo "Existing installation detected! Using rake db:migrate."
+      echo "Existing installation detected! Backing up and using rake db:migrate."
+      rake backup
       rake db:migrate
     else
       echo "Fresh VM installation detected! Using rake db:setup."

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -52,14 +52,25 @@ task :'fresh:db' do
 end
 
 task :'db:configure' do
-  if File.exist?("#{deploy_to}/shared/config/dbExists")
-    queue %[echo "Existing installation, migrating"]
-    invoke :'rails:db_migrate'
-  else
-    queue %[echo "Fresh installation, using db:setup"]
-    invoke :'fresh:db'
-    queue! %[touch "#{deploy_to}/#{shared_path}/config/dbExists"]
-  end
+  queue! %{
+    targetpath="#{deploy_to}/#{shared_path}/config/dbExists"
+    if [ -e "$targetpath" ]
+    then
+      echo "Existing installation detected! Using rake db:migrate."
+      rake db:migrate
+    else
+      echo "Fresh VM installation detected! Using rake db:setup."
+      read -r -p "Blank installation detected, are you sure you wish to continue? [y/n] " response
+      if [[ $response =~ ^([yY][eE][sS]|[yY])$ ]]
+        then
+          rake db:setup
+          touch "#{deploy_to}/#{shared_path}/config/dbExists"
+        else
+          echo "Quitting deployment."
+          exit 1
+      fi 
+    fi
+  }
 end
 
 #Execute all setup tasks defined below


### PR DESCRIPTION
Added the following to mina deploy:

1) Now requests manual user intervention before proceeding with generating a fresh database. (y/n) user input.

2) If an existing database installation is detected now invokes the rake backup task prior to proceeding with the remaining deployment.
