### PR TITLE
Mina deployment update

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -118,7 +118,7 @@ task :setup => :environment do
   queue  %[echo "-----> Be sure to edit '#{deploy_to}/#{shared_path}/config/web_action_api.yml'."]
 
   queue! %[touch "#{deploy_to}/#{shared_path}/config/config/secrets.yml"]
-  queue  %[echo "-----> Be sure to edit '#{deploy_to}/#{shared_path}/config/config/secrets.yml'."]
+  queue  %[echo "-----> Be sure to edit '#{deploy_to}/#{shared_path}/config/secrets.yml'."]
 
   if repository
     repo_host = repository.split(%r{@|://}).last.split(%r{:|\/}).first

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -25,9 +25,6 @@ set :shared_paths, ['config/database.yml', 'log', 'tmp', 'config/web_action_api.
 #   set :port, '30000'     # SSH port number.
 set :forward_agent, true     # SSH forward_agent.
 
-#Database configuration check
-set :dbconncheck, lamdba { "#{connexchk}" }
-
 
 ##########################################################################
 #


### PR DESCRIPTION
This update includes:

1) The re-write of the db:configure task into shell script. This mirrors the changes already applied to the mina deploy file for the API. 

2) Addition of a user input prompt prior to deploying a fresh database instance.

3) Unbundling of the db:setup command into db:create migrate and seed. This removes the db:schema:load command, essentially adding another safety catch to deployment.

This pull request now supercedes the mar16 branch.
