### PR TITLE
HTML layout fixes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,6 +156,8 @@ GEM
     jquery-rails (3.1.4)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
+    jquery-slick-rails (1.6.0.1)
+      railties (>= 3.1)
     jquery-ui-rails (5.0.5)
       railties (>= 3.2.16)
     json (1.8.3)
@@ -324,6 +326,7 @@ DEPENDENCIES
   factory_girl_rails
   jbuilder (~> 2.0)
   jquery-rails
+  jquery-slick-rails
   mysql2
   omniauth
   omniauth-facebook
@@ -343,3 +346,6 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   validates_formatting_of
   will_paginate-bootstrap
+
+BUNDLED WITH
+   1.10.6

--- a/app/assets/javascripts/initialize.coffee
+++ b/app/assets/javascripts/initialize.coffee
@@ -1,6 +1,6 @@
 jQuery ->
 	$('.scroller').slick({
-		dots: true,
+		dots: false,
 		fade: true,
 		centerMode: true,
 		variableWidth: true,

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -257,7 +257,7 @@ a.btn-extra:focus {
 
 .slick-slide {
   text-align: center;
-  height: 1000px;
+  height: 650px;
   width: 0px;
 }
 

--- a/app/models/run_test.rb
+++ b/app/models/run_test.rb
@@ -16,7 +16,6 @@ class RunTest < ActiveRecord::Base
   def screenshot_count(browser_type_id)
     imagearray = screenshots(browser_type_id)
     imagearray = imagearray.reject { |c| c.empty? } #trim blanks from array
-    logger.debug "Screenshot array count is #{imagearray.count}"
     imagearray.count
   rescue NoMethodError
     return 0

--- a/app/models/run_test.rb
+++ b/app/models/run_test.rb
@@ -15,7 +15,9 @@ class RunTest < ActiveRecord::Base
 
   def screenshot_count(browser_type_id)
     imagearray = screenshots(browser_type_id)
-    imagearray[1].count #selects the inner array and counts across the images present
+    imagearray = imagearray.reject { |c| c.empty? } #trim blanks from array
+    logger.debug "Screenshot array count is #{imagearray.count}"
+    imagearray.count
   rescue NoMethodError
     return 0
   end

--- a/app/views/runs/show.html.erb
+++ b/app/views/runs/show.html.erb
@@ -40,12 +40,6 @@
   <table class="table table-striped">
     <tbody>
       <% @run.run_tests.each do |run_test| %>
-        <tr>
-          <td class="testaction-toggle run-test-name-column cursor-hand"><%= run_test.name %></td>
-          <td class="testaction-toggle run-test-description-column"><%= run_test.description %></td>
-          <td class="run-test-success-column"><%= display_test_status(run_test) %><%= carousel_playback_button(run_test, run_test.id) %><div class="clearfix"></div></td>
-        </tr>
-        <tr class="testaction-row">
         <%- run_browser_ids(run_test.id).map do |browser| %>
           <%= tag("div", class: ["outer-scroll-#{browser}"], id: ["outer-scroll-#{browser}"], style: ["display: none"]) %>
           <%= tag("div", class: ["scroller margin-zero-auto"]) %>
@@ -59,11 +53,16 @@
             </div>
             </div>
         <%- end %>
-        
-          <td colspan='3'></td>
+        <tr>
+          <td class="testaction-toggle run-test-name-column cursor-hand"><%= run_test.name %></td>
+          <td class="testaction-toggle run-test-description-column"><%= run_test.description %></td>
+          <td class="run-test-success-column"><%= display_test_status(run_test) %><%= carousel_playback_button(run_test, run_test.id) %><div class="clearfix"></div></td>
+        </tr>
+        <tr class="testaction-row" style="display: none;">
+
+          <td colspan="3">
             <div class="fieldset test-action-table-container">
-                
-              
+                              
               <h4>Test Actions</h4>
 
               <div class="run-test-actions">
@@ -74,6 +73,7 @@
                       <th class="run-testaction-description-column">Description</th>
                       <th class="run-testaction-activity-column">Action</th>
                       <th class="run-testaction-success-column">Step Status</th>
+                      </td>
                     </tr>
                   </thead>
                   <tbody>

--- a/app/views/runs/show.html.erb
+++ b/app/views/runs/show.html.erb
@@ -13,6 +13,22 @@
   <h6>Environment: <code><%= @run.environment.name %></code></h6>
   <h6>Created: <%= l @run.created_at, format: :short %></h6>
 
+  <% @run.run_tests.each do |run_test| %>
+    <%- run_browser_ids(run_test.id).map do |browser| %>
+      <%= tag("div", class: ["outer-scroll-#{browser}"], id: ["outer-scroll-#{browser}"], style: ["display: none"]) %>
+      <%= tag("div", class: ["scroller margin-zero-auto"]) %>
+            <%- for @screenshot in run_test.screenshots(browser) %>
+              <%- for @base64string in @screenshot %>
+                <%= tag("div", class: ["margin-zero-auto"]) %>
+                <img src="data:image/png;base64,<%= @base64string %>">
+                </div>
+              <%- end %>
+            <%- end %>
+        </div>
+        </div>
+     <%- end %>
+
+
   <!--<div class="form-group">
     <% link_to t('.destroy', :default => t("helpers.links.destroy")),
                 collection_run_path(@run.collection, @run),
@@ -37,22 +53,9 @@
   </div>
   -->
 
-  <table class="table table-striped">
-    <tbody>
-      <% @run.run_tests.each do |run_test| %>
-        <%- run_browser_ids(run_test.id).map do |browser| %>
-          <%= tag("div", class: ["outer-scroll-#{browser}"], id: ["outer-scroll-#{browser}"], style: ["display: none"]) %>
-          <%= tag("div", class: ["scroller margin-zero-auto"]) %>
-                <%- for @screenshot in run_test.screenshots(browser) %>
-                  <%- for @base64string in @screenshot %>
-                    <%= tag("div", class: ["margin-zero-auto"]) %>
-                    <img src="data:image/png;base64,<%= @base64string %>" align= "center">
-                   </div>
-                  <%- end %>
-                <%- end %>
-            </div>
-            </div>
-        <%- end %>
+  <table class="table table-striped" style="table-layout:fixed">
+       
+        <tbody>
         <tr>
           <td class="testaction-toggle run-test-name-column cursor-hand"><%= run_test.name %></td>
           <td class="testaction-toggle run-test-description-column"><%= run_test.description %></td>
@@ -73,7 +76,7 @@
                       <th class="run-testaction-description-column">Description</th>
                       <th class="run-testaction-activity-column">Action</th>
                       <th class="run-testaction-success-column">Step Status</th>
-                      </td>
+                      
                     </tr>
                   </thead>
                   <tbody>
@@ -111,14 +114,14 @@
                         <% else %>
                           (none)
                         <%- end %>
-                      </td>
+                    
                     </tr>
                   <%- end %>
                   </tbody>
                 </table>
               </div>
 
-            </td>
+            
           </tr>
           <% end %>
         </tbody>

--- a/app/views/runs/show.html.erb
+++ b/app/views/runs/show.html.erb
@@ -114,12 +114,14 @@
                         <% else %>
                           (none)
                         <%- end %>
+                        </td>
                     
                     </tr>
                   <%- end %>
                   </tbody>
                 </table>
               </div>
+              </td>
 
             
           </tr>


### PR DESCRIPTION
Fixes for HTML layout bug as detailed under issue QAA-302. 

Also includes better handling of the carousel playback button and removes the dot track from the carousel due to poor handling for large numbers of images.
