### PR TITLE
Jun13 duplicate run btn disable

### DIFF
--- a/app/assets/stylesheets/collection.css.scss
+++ b/app/assets/stylesheets/collection.css.scss
@@ -144,3 +144,9 @@
 .pointer-link:focus {
   background-color: inherit;
 }
+
+a.disabled {
+  opacity: 0.5;
+  pointer-events: none;
+  cursor: default
+}

--- a/app/controllers/testsets_controller.rb
+++ b/app/controllers/testsets_controller.rb
@@ -2,7 +2,7 @@ class TestsetsController < ApplicationController
   before_action :authenticate_user!
   before_action :reset_errors
 
-  before_action :set_testset, only: [:show, :new, :edit, :show, :update, :destroy, :change_order]
+  before_action :set_testset, only: [:show, :edit, :show, :update, :destroy, :change_order]
   before_action :set_collection, only: [:index, :new, :show, :edit, :update, :destroy, :change_order]
   before_action :set_owner, only: [:show, :new, :edit, :show, :update, :destroy, :change_order]
 

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -98,11 +98,6 @@
                         :class => 'btn btn-primary',
                         :id => 'execution-tests-button'%>
 
-            <!-- <%= button_to "Execute tests ►",
-                          new_collection_run_path(:collection_id => @collection.id),
-                          :id => 'execution-tests-button-2',
-                          :disable_with => 'Launching Run'%> -->
-
 
 
             </div>

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -96,7 +96,15 @@
             <%= link_to "Execute tests ►",
                         new_collection_run_path(:collection_id => @collection.id),
                         :class => 'btn btn-primary',
-                        :id => 'execution-tests-button' %>
+                        :id => 'execution-tests-button'%>
+
+            <!-- <%= button_to "Execute tests ►",
+                          new_collection_run_path(:collection_id => @collection.id),
+                          :id => 'execution-tests-button-2',
+                          :disable_with => 'Launching Run'%> -->
+
+
+
             </div>
           </div>
         <% end %>
@@ -159,6 +167,7 @@
       $(this).text("Run Selected Tests");
     });
 
+
     submitSteps = function() {
       $('.testset-checkbox').each(function(i, obj) {
         var testsetId = $(obj).val();
@@ -218,9 +227,11 @@
 
     $('#execution-tests-button').click(function(e) {
       browser_selected = false;
+      $('#execution-tests-button').addClass('disabled')
       $('.browser-type-checkbox').each(function(i, obj) {
         if ($(obj).is(':checked')) {
           browser_selected = true;
+          e.preventDefault
         }
       });
 

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -227,11 +227,9 @@
 
     $('#execution-tests-button').click(function(e) {
       browser_selected = false;
-      $('#execution-tests-button').addClass('disabled')
       $('.browser-type-checkbox').each(function(i, obj) {
         if ($(obj).is(':checked')) {
           browser_selected = true;
-          e.preventDefault
         }
       });
 
@@ -269,6 +267,7 @@
         return false;
       }
 
+      $('#execution-tests-button').addClass('disabled')
       e.stopPropagation()
       e.preventDefault();
 


### PR DESCRIPTION
As noted in QAA-299 steps have already been taken to avoid duplication of runs being generated. However, it was still possible to bypass this in certain cases by rapidly hitting the Execute Test button (unable to replicate this in local dev environment, only seen in reports from user).

I've added a disabled class to CSS and small Javascript addition to apply the class to Execute Test button when a successful click is made by the end user.

This PR also includes a minor patch to the testsets_controller.rb resolving an issue when clicking the New Test button.
