### PR TITLE
Jun29 pointer selection fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,8 @@ gem 'delayed_job_active_record'
 gem 'daemons'
 gem 'symmetric-encryption'
 
+gem 'bootstrap_form'
+
 group :development do
   gem 'better_errors'
 end

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -17,6 +17,7 @@
 *= stub active_admin
 *= require slick
 *= require slick-theme
+*= require rails_bootstrap_forms
 *= require_self
 */
 @import "bootstrap_configuration";

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -4,4 +4,9 @@ class Collection < ActiveRecord::Base
 
   has_many :runs
   has_many :testsets, dependent: :destroy
+
+  def alphasort_testset
+  	testsets.order('name ASC');
+  end
+
 end

--- a/app/models/testset.rb
+++ b/app/models/testset.rb
@@ -1,7 +1,5 @@
 class Testset < ActiveRecord::Base
-
-  default_scope {order ('name ASC') }
-
+  
   belongs_to :collection
   belongs_to :user
 

--- a/app/models/testset.rb
+++ b/app/models/testset.rb
@@ -1,4 +1,7 @@
 class Testset < ActiveRecord::Base
+
+  default_scope {order ('name ASC') }
+
   belongs_to :collection
   belongs_to :user
 

--- a/app/views/test_actions/_pointer.html.erb
+++ b/app/views/test_actions/_pointer.html.erb
@@ -1,7 +1,7 @@
 <%= form_for [@testset.collection, @testset, @test_action], :html => { :class => 'form-horizontal form-model pointer-container' } do |f| %>
   <div class="form-group">
     <div class="col-md-12">
-      <%= f.collection_select(:pointer, Testset.where.not(id: @testset.id), :id, :name, {}, {:class => 'select-list form-control'}) %>
+      <%= f.grouped_collection_select(:pointer, Collection.all, :testsets, :name, :id, :name, {}, {:class => 'select-list form-control'})%>
     </div>
   </div>
   <%= f.hidden_field :testset_id, :value => @testset.id %>

--- a/app/views/test_actions/_pointer.html.erb
+++ b/app/views/test_actions/_pointer.html.erb
@@ -1,7 +1,7 @@
 <%= form_for [@testset.collection, @testset, @test_action], :html => { :class => 'form-horizontal form-model pointer-container' } do |f| %>
   <div class="form-group">
     <div class="col-md-12">
-      <%= f.grouped_collection_select(:pointer, Collection.all, :testsets, :name, :id, :name, {}, {:class => 'select-list form-control'})%>
+      <%= f.grouped_collection_select(:pointer, Collection.all, :alphasort_testset, :name, :id, :name, {}, {:class => 'select-list form-control'})%>
     </div>
   </div>
   <%= f.hidden_field :testset_id, :value => @testset.id %>


### PR DESCRIPTION
Add the rails-bootstrap gem and changes the pointer selection drop down to use a grouped_collection_select element.

Small addition to collection model to provide tiny method, returning alpha sorted list of sibling testsets.
