### PR TITLE
Jul20 statusupdate fix

### DIFF
--- a/app/helpers/runs_helper.rb
+++ b/app/helpers/runs_helper.rb
@@ -17,7 +17,7 @@ module RunsHelper
     run_test.test_statuses.map{ |status|
       link_to "#{status.browser_type.name}: #{status_success_display(status.success)}".html_safe,
                   collection_run_run_test_test_status_path(status.run_test.run.collection, status.run_test.run, status.run_test, status),
-                  :class => 'btn browser-test-status'
+                  :class => 'btn browser-test-status browser-type-' + "#{status.browser_type.id}"
     }.join(' ').html_safe
   end
 
@@ -42,7 +42,7 @@ module RunsHelper
     rta.action_statuses.map{ |status|
       link_to "#{status.browser_type.name}: #{status_success_display(status.success)}".html_safe,
                   collection_run_run_test_run_test_action_action_status_path(status.run_test_action.run_test.run.collection, status.run_test_action.run_test.run, status.run_test_action.run_test, status.run_test_action, status),
-                  :class => 'btn browser-action-status'
+                  :class => 'btn browser-action-status browser-type-' + "#{status.browser_type.id}"
     }.join(' ').html_safe
   end
 

--- a/app/views/runs/show.html.erb
+++ b/app/views/runs/show.html.erb
@@ -170,15 +170,24 @@
     $('.action-element-row').hide();
 
     function updateItems() {
-      var update_target = document.getElementById(btnids[0]).getElementsByClassName("status-pending");
-      if (update_target) {
-        var url = $(location).attr('href') + '/update_action_status'; //obtain current URL and append our method call
-        $('#' + value).load(url, 'status_action_id=' + value);  //pass the URL along with a parameter
+      if (btnids.length > 0) {
+        var update_target = (btnids[0]);
+        var update_target_status = document.getElementById(btnids[0]).getElementsByClassName("status-pending");
+        if (update_target_status.length > 0) {
+          console.log(update_target_status);
+          var url = $(location).attr('href') + '/update_action_status'; //obtain current URL and append our method call
+          $('#' + update_target).load(url, 'status_action_id=' + update_target);  //pass the URL along with a parameter
+        }
+        else {
+          btnids.shift();
+          //console.log(btnids);
+        }
       }
-
-      console.log(update_target);
-      
-
+      else {
+        console.log("Exiting loop!");
+        return;
+        }
+      };
 
 
       //$.each(btnids, function( index, value ) {
@@ -190,9 +199,14 @@
       //  var status_url = $(location).attr('href') + '/update_run_status'; //obtain current URL and append our method call
       //  $('#' + value).load(status_url, 'test_status_id=' + value);  //pass the URL along with a parameter
       //});
+    
+    var failpresent = document.getElementsByClassName("status-failed");
+    if (failpresent.length > 0) {
+      console.log("Failed run detected. No status updates will be processed.");
     }
-
-    var refreshStatus = setInterval(updateItems, 3000);
+    else {
+      var refreshStatus = setInterval(updateItems, 3000);
+    }
 
     $('.testaction-toggle').click(function (i, obj) {
       $(this).parent().next('tr').toggle('fast', function() {

--- a/app/views/runs/show.html.erb
+++ b/app/views/runs/show.html.erb
@@ -172,6 +172,7 @@
     function updateItems() {
       $.each(btnids, function( index, value ) {
         var url = $(location).attr('href') + '/update_action_status'; //obtain current URL and append our method call
+        console.log(value);
         $('#' + value).load(url, 'status_action_id=' + value);  //pass the URL along with a parameter
       });
       $.each(statusids, function( index, value ) {
@@ -180,7 +181,7 @@
       });
     }
 
-    var refreshStatus = setInterval(updateItems, 15000);
+    var refreshStatus = setInterval(updateItems, 3000);
 
     $('.testaction-toggle').click(function (i, obj) {
       $(this).parent().next('tr').toggle('fast', function() {

--- a/app/views/runs/show.html.erb
+++ b/app/views/runs/show.html.erb
@@ -145,7 +145,7 @@
     {
       list_btn_ids.push(value.id); //returns array of unique id's for the action status buttons on the page
     });
-    return(list_btn_ids);
+    return(list_btn_ids.sort());
   };
 
   function gatherStatusBtnIds() {
@@ -170,15 +170,26 @@
     $('.action-element-row').hide();
 
     function updateItems() {
-      $.each(btnids, function( index, value ) {
+      var update_target = document.getElementById(btnids[0]).getElementsByClassName("status-pending");
+      if (update_target) {
         var url = $(location).attr('href') + '/update_action_status'; //obtain current URL and append our method call
-        console.log(value);
         $('#' + value).load(url, 'status_action_id=' + value);  //pass the URL along with a parameter
-      });
-      $.each(statusids, function( index, value ) {
-        var status_url = $(location).attr('href') + '/update_run_status'; //obtain current URL and append our method call
-        $('#' + value).load(status_url, 'test_status_id=' + value);  //pass the URL along with a parameter
-      });
+      }
+
+      console.log(update_target);
+      
+
+
+
+      //$.each(btnids, function( index, value ) {
+      //  var url = $(location).attr('href') + '/update_action_status'; //obtain current URL and append our method call
+       // console.log(index, value);
+      //  $('#' + value).load(url, 'status_action_id=' + value);  //pass the URL along with a parameter
+      //});
+      //$.each(statusids, function( index, value ) {
+      //  var status_url = $(location).attr('href') + '/update_run_status'; //obtain current URL and append our method call
+      //  $('#' + value).load(status_url, 'test_status_id=' + value);  //pass the URL along with a parameter
+      //});
     }
 
     var refreshStatus = setInterval(updateItems, 3000);

--- a/app/views/runs/show.html.erb
+++ b/app/views/runs/show.html.erb
@@ -138,50 +138,41 @@
 
 </div>
 <script>
-  function gatherBtnIds() {
-   var list_btn_ids = [];
-   var action_btn_elements = document.getElementsByClassName("action-status-btn");
-   $.each(action_btn_elements, function ( index, value )
-    {
-      list_btn_ids.push(value.id); //returns array of unique id's for the action status buttons on the page
-    });
-    return(list_btn_ids.sort());
-  };
 
-  function gatherStatusBtnIds() {
-    var status_btn_ids = [];
-    var status_btn_elements = document.getElementsByClassName("run-status-btn");
+  var action_buttons_class = "action-status-btn"
+  var action_buttons_browser_class = "browser-action-status"
+
+  var status_buttons_class = "run-status-btn"
+  var status_buttons_browser_class = "browser-test-status"
+
+  function gatherStatusBtnIds(button_type, browser_class) {
+    var status_btn_ids = new Map();
+    var status_btn_elements = document.getElementsByClassName(button_type);
     $.each(status_btn_elements, function ( index, value )
     {
-      status_btn_ids.push(value.id);
+      var browid = gatherBrowserIds(value.id, browser_class);
+      status_btn_ids.set(value.id, browid);
     });
-    //console.log(status_btn_ids.length);
     return(status_btn_ids);
   };
 
-  function gatherBrowserIds() {
+  function gatherBrowserIds(html_element_id, class_identifier) {
     var re = new RegExp(/browser-type-\d*/);
     var status_browser_ids = [];
-    var run_status_btns = document.getElementsByClassName("browser-test-status");
-    for (var i = 0; i < run_status_btns.length; i++) {
-      var node = run_status_btns.item(i);
-      var result = node.getAttribute('class').match(re);
-      status_browser_ids.push(result[0]);
-    }
+    var run_status_btn = document.getElementById(html_element_id).getElementsByClassName(class_identifier);
+    var node = run_status_btn.item(0);
+    var result = node.getAttribute('class').match(re);
+    return(result[0]);
   };
-      
-
-  var btnids = gatherBtnIds();
-  var statusids = gatherStatusBtnIds();
-  var foo_browsers = gatherBrowserIds();
-  
-  console.log("Browser IDs hash " + foo_browsers);
-
+ 
+  var statusids = gatherStatusBtnIds(status_buttons_class, status_buttons_browser_class); //array containing overall Run Status buttons
+  var btnids_map = gatherStatusBtnIds(action_buttons_class, action_buttons_browser_class); //array containing all Action Status buttons
+    
   var pendingRuns = []
 
-  $.each(statusids, function(index, value) { //parse the list of overall run status buttons for any items that are in Pending status
-   pendingRuns.push(document.getElementById(value).getElementsByClassName("status-pending"));
-  });
+  statusids.forEach(function (value, key) {
+    pendingRuns.push(document.getElementById(key).getElementsByClassName("status-pending"));
+  }, statusids)
 
 </script>
 <script>
@@ -203,24 +194,34 @@
     };
 
     function updateItems() {
-      if (btnids.length > 0 && total_runs !== failed_runs.length) {
-        var update_target = (btnids[0]);
-        var update_target_status = document.getElementById(btnids[0]).getElementsByClassName("status-pending");
+      if (btnids_map.size > 0) {  
+        var btnids = btnids_map.keys();
+        var update_target = btnids.next().value;
+        var update_target_status = document.getElementById(update_target).getElementsByClassName("status-pending");
         if (update_target_status.length > 0) {
           var url = $(location).attr('href') + '/update_action_status'; //obtain current URL and append our method call
           $('#' + update_target).load(url, 'status_action_id=' + update_target);  //pass the URL along with a parameter
         }
         else {
-          var recent_status_btn = document.getElementById(btnids[0]);
-          var fail_list = recent_status_btn.getElementsByClassName("status-failed"); //next 4 lines looks at the button just updated and adds it to the failed_runs array if required
-          for (var i = 0; i < fail_list.length; i++) {
-            failed_runs.push(i);
+          var fail_list = document.getElementById(update_target).getElementsByClassName("status-failed");
+          if (fail_list.length > 0) {
+            var failed_browid = btnids_map.get(update_target);
+            for (var [key, value] of btnids_map) { //remove all items from the array that share the same browser ID
+              if (value == failed_browid) {
+                btnids_map.delete(key);
+              }
+              else {
+                console.log("Browser ID didn't match, not deleting.")
+              }
+            }
+          }  
+          else {
+            btnids_map.delete(update_target); //remove recently Passed item from the list
           }
-          btnids.shift(); //drop off the button ID just checked
         }
       }
       else {
-        $.each(statusids, function( index, value ) { //once all of the action statuses are updated, drop through to here to update the overall run status buttons
+        statusids.forEach(function (index, value) { //once all of the action statuses are updated, drop through to here to update the overall run status buttons
          var status_url = $(location).attr('href') + '/update_run_status'; //obtain current URL and append our method call
          $('#' + value).load(status_url, 'test_status_id=' + value);  //pass the URL along with a parameter
         });

--- a/app/views/runs/show.html.erb
+++ b/app/views/runs/show.html.erb
@@ -165,18 +165,18 @@
     return(result[0]);
   };
  
-  var statusids = gatherStatusBtnIds(status_buttons_class, status_buttons_browser_class); //array containing overall Run Status buttons
-  var btnids_map = gatherStatusBtnIds(action_buttons_class, action_buttons_browser_class); //array containing all Action Status buttons
-    
-  var pendingRuns = []
-
-  statusids.forEach(function (value, key) {
-    pendingRuns.push(document.getElementById(key).getElementsByClassName("status-pending"));
-  }, statusids)
-
 </script>
 <script>
   $( document ).ready(function() {
+
+    var statusids = gatherStatusBtnIds(status_buttons_class, status_buttons_browser_class); //array containing overall Run Status buttons
+    var btnids_map = gatherStatusBtnIds(action_buttons_class, action_buttons_browser_class); //array containing all Action Status buttons
+    
+    var pendingRuns = []
+
+    statusids.forEach(function (value, key) {
+      pendingRuns.push(document.getElementById(key).getElementsByClassName("status-pending"));
+    }, statusids)
 
     $('.testaction-row').hide();
 

--- a/app/views/runs/show.html.erb
+++ b/app/views/runs/show.html.erb
@@ -168,7 +168,7 @@
     $('.testaction-row').hide();
 
     $('.action-element-row').hide();
-
+    
     function updateItems() {
       if (btnids.length > 0) {
         var update_target = (btnids[0]);
@@ -180,7 +180,6 @@
         }
         else {
           btnids.shift();
-          //console.log(btnids);
         }
       }
       else {
@@ -200,6 +199,8 @@
       //  $('#' + value).load(status_url, 'test_status_id=' + value);  //pass the URL along with a parameter
       //});
     
+
+    //check on page load if run is failed, if so don't start checking for action status updates
     var failpresent = document.getElementsByClassName("status-failed");
     if (failpresent.length > 0) {
       console.log("Failed run detected. No status updates will be processed.");

--- a/app/views/runs/show.html.erb
+++ b/app/views/runs/show.html.erb
@@ -155,6 +155,7 @@
     {
       status_btn_ids.push(value.id);
     });
+    //console.log(status_btn_ids.length);
     return(status_btn_ids);
   };
 
@@ -174,17 +175,20 @@
     $('.testaction-row').hide();
 
     $('.action-element-row').hide();
+
+    var total_runs = statusids.length;
+    var failed_runs = [];
     
     if (pendingRuns[0].length > 0) { //on page ready check if the overall run statuses are Passed/Failed. If so we don't need to start live updating of run status buttons.
       console.log("Pending run detected, launching live update status.")
-      var refreshStatus = setInterval(updateItems, 7000);
+      var refreshStatus = setInterval(updateItems, 12000);
     }
     else {
       console.log("Overall run status already updated. No live updates will be processed.");
     };
 
     function updateItems() {
-      if (btnids.length > 0) {
+      if (btnids.length > 0 && total_runs !== failed_runs.length) {
         var update_target = (btnids[0]);
         var update_target_status = document.getElementById(btnids[0]).getElementsByClassName("status-pending");
         if (update_target_status.length > 0) {
@@ -192,6 +196,11 @@
           $('#' + update_target).load(url, 'status_action_id=' + update_target);  //pass the URL along with a parameter
         }
         else {
+          var recent_status_btn = document.getElementById(btnids[0]);
+          var fail_list = recent_status_btn.getElementsByClassName("status-failed"); //next 4 lines looks at the button just updated and adds it to the failed_runs array if required
+          for (var i = 0; i < fail_list.length; i++) {
+            failed_runs.push(i);
+          }
           btnids.shift(); //drop off the button ID just checked
         }
       }
@@ -201,26 +210,9 @@
          $('#' + value).load(status_url, 'test_status_id=' + value);  //pass the URL along with a parameter
         });
         console.log("Exiting status update loop!");
-        clearInterval(refreshStatus);
+        clearInterval(refreshStatus); //kill the entire status refresh loop
         }
       };
-
-
-      //$.each(btnids, function( index, value ) {
-      //  var url = $(location).attr('href') + '/update_action_status'; //obtain current URL and append our method call
-       // console.log(index, value);
-      //  $('#' + value).load(url, 'status_action_id=' + value);  //pass the URL along with a parameter
-      //});
-      //$.each(statusids, function( index, value ) {
-      //  var status_url = $(location).attr('href') + '/update_run_status'; //obtain current URL and append our method call
-      //  $('#' + value).load(status_url, 'test_status_id=' + value);  //pass the URL along with a parameter
-      //});
-    
-
-    //check on page load if run is failed, if so don't start checking for action status updates
-    //var live_update_required = document.getElementsByClassName("status-failed");
-
-
 
     $('.testaction-toggle').click(function (i, obj) {
       $(this).parent().next('tr').toggle('fast', function() {

--- a/app/views/runs/show.html.erb
+++ b/app/views/runs/show.html.erb
@@ -161,6 +161,12 @@
   var btnids = gatherBtnIds()
   var statusids = gatherStatusBtnIds()
 
+  var pendingRuns = []
+
+  $.each(statusids, function(index, value) { //parse the list of overall run status buttons for any items that are in Pending status
+   pendingRuns.push(document.getElementById(value).getElementsByClassName("status-pending"));
+  });
+
 </script>
 <script>
   $( document ).ready(function() {
@@ -169,22 +175,33 @@
 
     $('.action-element-row').hide();
     
+    if (pendingRuns[0].length > 0) { //on page ready check if the overall run statuses are Passed/Failed. If so we don't need to start live updating of run status buttons.
+      console.log("Pending run detected, launching live update status.")
+      var refreshStatus = setInterval(updateItems, 7000);
+    }
+    else {
+      console.log("Overall run status already updated. No live updates will be processed.");
+    };
+
     function updateItems() {
       if (btnids.length > 0) {
         var update_target = (btnids[0]);
         var update_target_status = document.getElementById(btnids[0]).getElementsByClassName("status-pending");
         if (update_target_status.length > 0) {
-          console.log(update_target_status);
           var url = $(location).attr('href') + '/update_action_status'; //obtain current URL and append our method call
           $('#' + update_target).load(url, 'status_action_id=' + update_target);  //pass the URL along with a parameter
         }
         else {
-          btnids.shift();
+          btnids.shift(); //drop off the button ID just checked
         }
       }
       else {
-        console.log("Exiting loop!");
-        return;
+        $.each(statusids, function( index, value ) { //once all of the action statuses are updated, drop through to here to update the overall run status buttons
+         var status_url = $(location).attr('href') + '/update_run_status'; //obtain current URL and append our method call
+         $('#' + value).load(status_url, 'test_status_id=' + value);  //pass the URL along with a parameter
+        });
+        console.log("Exiting status update loop!");
+        clearInterval(refreshStatus);
         }
       };
 
@@ -201,13 +218,9 @@
     
 
     //check on page load if run is failed, if so don't start checking for action status updates
-    var failpresent = document.getElementsByClassName("status-failed");
-    if (failpresent.length > 0) {
-      console.log("Failed run detected. No status updates will be processed.");
-    }
-    else {
-      var refreshStatus = setInterval(updateItems, 3000);
-    }
+    //var live_update_required = document.getElementsByClassName("status-failed");
+
+
 
     $('.testaction-toggle').click(function (i, obj) {
       $(this).parent().next('tr').toggle('fast', function() {

--- a/app/views/runs/show.html.erb
+++ b/app/views/runs/show.html.erb
@@ -157,12 +157,21 @@
   };
 
   function gatherBrowserIds(html_element_id, class_identifier) {
-    var re = new RegExp(/browser-type-\d*/);
+    var re_browtype = new RegExp(/browser-type-\d*/);
+    var re_runtestid = new RegExp(/run_tests\/\d*/);
     var status_browser_ids = [];
     var run_status_btn = document.getElementById(html_element_id).getElementsByClassName(class_identifier);
     var node = run_status_btn.item(0);
-    var result = node.getAttribute('class').match(re);
-    return(result[0]);
+    if (class_identifier == 'browser-action-status') { //if it's an action button give me the run test id
+    	var result = node.getAttribute('href').match(re_runtestid);
+    	var result = result[0].split("/");
+    	result = result[1];
+    }
+    else { //if it's an overall run test button give me the browser ID
+    	var result = node.getAttribute('class').match(re_browtype);
+    	var result = result[0]
+    }
+    return(result);
   };
  
 </script>
@@ -181,9 +190,6 @@
     $('.testaction-row').hide();
 
     $('.action-element-row').hide();
-
-    var total_runs = statusids.length;
-    var failed_runs = [];
     
     if (pendingRuns[0].length > 0) { //on page ready check if the overall run statuses are Passed/Failed. If so we don't need to start live updating of run status buttons.
       console.log("Pending run detected, launching live update status.")
@@ -205,13 +211,13 @@
         else {
           var fail_list = document.getElementById(update_target).getElementsByClassName("status-failed");
           if (fail_list.length > 0) {
-            var failed_browid = btnids_map.get(update_target);
+            var failed_runstatus = btnids_map.get(update_target);
             for (var [key, value] of btnids_map) { //remove all items from the array that share the same browser ID
-              if (value == failed_browid) {
+              if (value == failed_runstatus) {
                 btnids_map.delete(key);
               }
               else {
-                console.log("Browser ID didn't match, not deleting.")
+                console.log("Run status ID didn't match, not deleting.")
               }
             }
           }  

--- a/app/views/runs/show.html.erb
+++ b/app/views/runs/show.html.erb
@@ -139,8 +139,8 @@
 </div>
 <script>
   function gatherBtnIds() {
-   var list_btn_ids = []
-   var action_btn_elements = document.getElementsByClassName("action-status-btn")
+   var list_btn_ids = [];
+   var action_btn_elements = document.getElementsByClassName("action-status-btn");
    $.each(action_btn_elements, function ( index, value )
     {
       list_btn_ids.push(value.id); //returns array of unique id's for the action status buttons on the page
@@ -149,8 +149,8 @@
   };
 
   function gatherStatusBtnIds() {
-    var status_btn_ids = []
-    var status_btn_elements = document.getElementsByClassName("run-status-btn") 
+    var status_btn_ids = [];
+    var status_btn_elements = document.getElementsByClassName("run-status-btn");
     $.each(status_btn_elements, function ( index, value )
     {
       status_btn_ids.push(value.id);
@@ -159,8 +159,23 @@
     return(status_btn_ids);
   };
 
-  var btnids = gatherBtnIds()
-  var statusids = gatherStatusBtnIds()
+  function gatherBrowserIds() {
+    var re = new RegExp(/browser-type-\d*/);
+    var status_browser_ids = [];
+    var run_status_btns = document.getElementsByClassName("browser-test-status");
+    for (var i = 0; i < run_status_btns.length; i++) {
+      var node = run_status_btns.item(i);
+      var result = node.getAttribute('class').match(re);
+      status_browser_ids.push(result[0]);
+    }
+  };
+      
+
+  var btnids = gatherBtnIds();
+  var statusids = gatherStatusBtnIds();
+  var foo_browsers = gatherBrowserIds();
+  
+  console.log("Browser IDs hash " + foo_browsers);
 
   var pendingRuns = []
 


### PR DESCRIPTION
Reworked the live updating of the overall Run Status buttons and the individual Action Status buttons. In order to reduce server load the javascript now works as follows:

1) On initial page load, assess whether the runs have already been completed. If so no further action is taken.
2) Only submit and AJAX request every 12 secs to refresh the current action awaiting processing.
3) Detect if the most recent action updated was a failure. If all runs on a page have failed, then update the overall Run Status buttons and then cease processing.
4) Only issue an AJAX request to update the overall Run Status buttons once the run has been completed (Passed or Failed).

This should limit each browser to a max of 5 AJAX requests per minute. Each request is asking to retrieve the status for a single button only. As a result overhead should be dramatically reduced now.

Please test locally before passing code review.

Ideally in future this whole suite of functionality should be replaced with Rails Action-Cable etc.
